### PR TITLE
Child containers are injected as dependencies

### DIFF
--- a/Sources/Resolve.swift
+++ b/Sources/Resolve.swift
@@ -135,6 +135,11 @@ extension DependencyContainer {
   
   /// Lookup definition by the key and use it to resolve instance. Fallback to the key with `nil` tag.
   func _resolve<T>(key aKey: DefinitionKey, builder: (_Definition) throws -> T) throws -> T {
+
+    if aKey.type == DependencyContainer.self {
+      return (context.inCollaboration ? self : context.container) as! T
+    }
+
     guard let matching = self.definition(matching: aKey) else {
       do {
         return try autowire(key: aKey)
@@ -193,11 +198,11 @@ extension DependencyContainer {
     
     if let resolvable = resolvedInstance as? Resolvable {
       resolvedInstances.resolvableInstances.append(resolvable)
-      resolvable.resolveDependencies(self)
+      resolvable.resolveDependencies(context.inCollaboration ? self : context.container)
     }
     
     try autoInjectProperties(in: resolvedInstance)
-    try definition.resolveProperties(of: resolvedInstance, container: self)
+    try definition.resolveProperties(of: resolvedInstance, container: context.inCollaboration ? self : context.container)
     
     log(level: .Verbose, "Resolved type \(key.type) with \(resolvedInstance)")
     return resolvedInstance


### PR DESCRIPTION
1.a) if you request a (container : DependencyContainer) as an dependency, you will receive one, and it will be the child container that initiated the resolve() call, not necessarily the one where it was registered.


```
parentContainer.register { (container: DependencyContainer) in 
     //container === childContainer !!!!
     Presenter() 
}.resolvingProperties( container, presneter ) {
  //container === childContainer !!!!
}

childContainer = DependencyContainer(parent: parentContainer)
childContainer.resolve() as Presenter()

```

1.b) Container that invokes the resolve call is always injected, even in utility functions like Resolvable