### PR TITLE
Add Recursive Depth check

### DIFF
--- a/Dip/Dip.xcodeproj/project.pbxproj
+++ b/Dip/Dip.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		09FC481E1DAAA8F900566AA8 /* ComponentScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC481C1DAAA8F900566AA8 /* ComponentScope.swift */; };
 		63937A6A21524C0B00AEE75A /* StoryboardInstantiatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63937A6921524C0B00AEE75A /* StoryboardInstantiatable.swift */; };
 		63937A6F21524DA300AEE75A /* DipUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63937A6B21524DA200AEE75A /* DipUITests.swift */; };
-		86134D0523C80D1800AB2A50 /* RecusiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86134D0423C80D1800AB2A50 /* RecusiveTests.swift */; };
+		86134D0523C80D1800AB2A50 /* RecursiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86134D0423C80D1800AB2A50 /* RecursiveTests.swift */; };
 		86418DEE1F510C9700ACFF23 /* RuntimeArguments+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86418DED1F510C9700ACFF23 /* RuntimeArguments+Generated.swift */; };
 		8652F4EB1F2C3D6000A92D4B /* ParentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8652F4EA1F2C3D6000A92D4B /* ParentTests.swift */; };
 /* End PBXBuildFile section */
@@ -81,7 +81,7 @@
 		63937A6C21524DA200AEE75A /* NSStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = NSStoryboard.storyboard; sourceTree = "<group>"; };
 		63937A6D21524DA300AEE75A /* TVStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = TVStoryboard.storyboard; sourceTree = "<group>"; };
 		63937A6E21524DA300AEE75A /* UIStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = UIStoryboard.storyboard; sourceTree = "<group>"; };
-		86134D0423C80D1800AB2A50 /* RecusiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecusiveTests.swift; sourceTree = "<group>"; };
+		86134D0423C80D1800AB2A50 /* RecursiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecursiveTests.swift; sourceTree = "<group>"; };
 		86418DED1F510C9700ACFF23 /* RuntimeArguments+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "RuntimeArguments+Generated.swift"; path = "../../Sources/RuntimeArguments+Generated.swift"; sourceTree = "<group>"; };
 		8652F4EA1F2C3D6000A92D4B /* ParentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParentTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -147,7 +147,7 @@
 				09BD350D1D84E30D00B33E53 /* Utils.swift */,
 				0919F4D11C16417000DC3B10 /* Info.plist */,
 				8652F4EA1F2C3D6000A92D4B /* ParentTests.swift */,
-				86134D0423C80D1800AB2A50 /* RecusiveTests.swift */,
+				86134D0423C80D1800AB2A50 /* RecursiveTests.swift */,
 			);
 			path = DipTests;
 			sourceTree = "<group>";
@@ -326,7 +326,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				09BD35141D84E30D00B33E53 /* RuntimeArgumentsTests.swift in Sources */,
-				86134D0523C80D1800AB2A50 /* RecusiveTests.swift in Sources */,
+				86134D0523C80D1800AB2A50 /* RecursiveTests.swift in Sources */,
 				09BD35151D84E30D00B33E53 /* ThreadSafetyTests.swift in Sources */,
 				63937A6F21524DA300AEE75A /* DipUITests.swift in Sources */,
 				09BD35121D84E30D00B33E53 /* DefinitionTests.swift in Sources */,

--- a/Dip/Dip.xcodeproj/project.pbxproj
+++ b/Dip/Dip.xcodeproj/project.pbxproj
@@ -31,10 +31,11 @@
 		09FC480F1DAA9CAF00566AA8 /* Register.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC480C1DAA9CAF00566AA8 /* Register.swift */; };
 		09FC48181DAAA53100566AA8 /* DipError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC48161DAAA53100566AA8 /* DipError.swift */; };
 		09FC481E1DAAA8F900566AA8 /* ComponentScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC481C1DAAA8F900566AA8 /* ComponentScope.swift */; };
-		86418DEE1F510C9700ACFF23 /* RuntimeArguments+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86418DED1F510C9700ACFF23 /* RuntimeArguments+Generated.swift */; };
-		8652F4EB1F2C3D6000A92D4B /* ParentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8652F4EA1F2C3D6000A92D4B /* ParentTests.swift */; };
 		63937A6A21524C0B00AEE75A /* StoryboardInstantiatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63937A6921524C0B00AEE75A /* StoryboardInstantiatable.swift */; };
 		63937A6F21524DA300AEE75A /* DipUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63937A6B21524DA200AEE75A /* DipUITests.swift */; };
+		86134D0523C80D1800AB2A50 /* RecusiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86134D0423C80D1800AB2A50 /* RecusiveTests.swift */; };
+		86418DEE1F510C9700ACFF23 /* RuntimeArguments+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86418DED1F510C9700ACFF23 /* RuntimeArguments+Generated.swift */; };
+		8652F4EB1F2C3D6000A92D4B /* ParentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8652F4EA1F2C3D6000A92D4B /* ParentTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,13 +76,14 @@
 		09FC480C1DAA9CAF00566AA8 /* Register.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Register.swift; path = ../../Sources/Register.swift; sourceTree = "<group>"; };
 		09FC48161DAAA53100566AA8 /* DipError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DipError.swift; path = ../../Sources/DipError.swift; sourceTree = "<group>"; };
 		09FC481C1DAAA8F900566AA8 /* ComponentScope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ComponentScope.swift; path = ../../Sources/ComponentScope.swift; sourceTree = "<group>"; };
-		86418DED1F510C9700ACFF23 /* RuntimeArguments+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "RuntimeArguments+Generated.swift"; path = "../../Sources/RuntimeArguments+Generated.swift"; sourceTree = "<group>"; };
-		8652F4EA1F2C3D6000A92D4B /* ParentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParentTests.swift; sourceTree = "<group>"; };
 		63937A6921524C0B00AEE75A /* StoryboardInstantiatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StoryboardInstantiatable.swift; path = ../../Sources/StoryboardInstantiatable.swift; sourceTree = "<group>"; };
 		63937A6B21524DA200AEE75A /* DipUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DipUITests.swift; path = ../../Tests/DipTests/DipUITests.swift; sourceTree = "<group>"; };
 		63937A6C21524DA200AEE75A /* NSStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = NSStoryboard.storyboard; sourceTree = "<group>"; };
 		63937A6D21524DA300AEE75A /* TVStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = TVStoryboard.storyboard; sourceTree = "<group>"; };
 		63937A6E21524DA300AEE75A /* UIStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = UIStoryboard.storyboard; sourceTree = "<group>"; };
+		86134D0423C80D1800AB2A50 /* RecusiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecusiveTests.swift; sourceTree = "<group>"; };
+		86418DED1F510C9700ACFF23 /* RuntimeArguments+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "RuntimeArguments+Generated.swift"; path = "../../Sources/RuntimeArguments+Generated.swift"; sourceTree = "<group>"; };
+		8652F4EA1F2C3D6000A92D4B /* ParentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParentTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -145,6 +147,7 @@
 				09BD350D1D84E30D00B33E53 /* Utils.swift */,
 				0919F4D11C16417000DC3B10 /* Info.plist */,
 				8652F4EA1F2C3D6000A92D4B /* ParentTests.swift */,
+				86134D0423C80D1800AB2A50 /* RecusiveTests.swift */,
 			);
 			path = DipTests;
 			sourceTree = "<group>";
@@ -245,6 +248,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 094526871BEA1CFF0034E72A;
@@ -322,6 +326,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				09BD35141D84E30D00B33E53 /* RuntimeArgumentsTests.swift in Sources */,
+				86134D0523C80D1800AB2A50 /* RecusiveTests.swift in Sources */,
 				09BD35151D84E30D00B33E53 /* ThreadSafetyTests.swift in Sources */,
 				63937A6F21524DA300AEE75A /* DipUITests.swift in Sources */,
 				09BD35121D84E30D00B33E53 /* DefinitionTests.swift in Sources */,

--- a/Dip/DipTests/ParentTests.swift
+++ b/Dip/DipTests/ParentTests.swift
@@ -24,11 +24,11 @@ class ParentTests: XCTestCase {
   }
 
 
-  class ServiceA {}
+  fileprivate class ServiceA {}
 
-  class Password {
+  fileprivate class Password {
     let text: String
-    let service : ServiceA
+    fileprivate let service : ServiceA
 
     init(text:String, service: ServiceA) {
       self.text = text

--- a/Dip/DipTests/RecursiveTests.swift
+++ b/Dip/DipTests/RecursiveTests.swift
@@ -1,5 +1,5 @@
 //
-//  RecusiveTests.swift
+//  RecursiveTests.swift
 //  DipTests
 //
 //  Created by John Twigg on 1/9/20.
@@ -10,7 +10,7 @@ import XCTest
 @testable import Dip
 
 
-class RecusiveTests: XCTestCase {
+class RecursiveTests: XCTestCase {
 
   
   fileprivate class ServiceC {

--- a/Dip/DipTests/RecursiveTests.swift
+++ b/Dip/DipTests/RecursiveTests.swift
@@ -34,7 +34,7 @@ class RecursiveTests: XCTestCase {
   }
   
   
-    func testRecuriveDepthReached() {
+    func testRecursiveDepthReached() {
         let container = DependencyContainer()
       
       container.register { (serviceA: ServiceA ) -> ServiceRoot in
@@ -59,7 +59,7 @@ class RecursiveTests: XCTestCase {
       } catch {
         switch error {
         case let dipError as DipError:
-          XCTAssert(dipError.isRecusiveError)
+          XCTAssert(dipError.isRecursiveError)
           
           guard let report = dipError.analyzeRecursiveError() else {
             XCTFail()

--- a/Dip/DipTests/RecursiveTests.swift
+++ b/Dip/DipTests/RecursiveTests.swift
@@ -66,6 +66,7 @@ class RecursiveTests: XCTestCase {
             return
           }
           print(report)
+          XCTAssert(report.cycleSubStack.count == 3)
         default:
           XCTFail()
         }

--- a/Dip/DipTests/RecusiveTests.swift
+++ b/Dip/DipTests/RecusiveTests.swift
@@ -1,0 +1,75 @@
+//
+//  RecusiveTests.swift
+//  DipTests
+//
+//  Created by John Twigg on 1/9/20.
+//  Copyright © 2020 AliSoftware. All rights reserved.
+//
+
+import XCTest
+@testable import Dip
+
+
+class RecusiveTests: XCTestCase {
+
+  
+  fileprivate class ServiceC {
+    init(_ serviceA: ServiceA) {
+      
+    }
+  }
+  fileprivate class ServiceB {
+    init(_ servicec: ServiceC) {
+         
+       }
+  }
+  fileprivate class ServiceA {
+    init(_ serviceB: ServiceB) {
+    }
+  }
+  
+  fileprivate class ServiceRoot {
+    init(_ serviceA: ServiceA) {
+    }
+  }
+  
+  
+    func testRecuriveDepthReached() {
+        let container = DependencyContainer()
+      
+      container.register { (serviceA: ServiceA ) -> ServiceRoot in
+             return ServiceRoot.init(serviceA)
+      }
+      
+      container.register { (serviceB: ServiceB ) -> ServiceA in
+        return ServiceA.init(serviceB)
+      }
+      
+      container.register { (serviceC: ServiceC ) -> ServiceB in
+        return ServiceB.init(serviceC)
+      }
+      
+      container.register { (serviceA: ServiceA ) -> ServiceC in
+             return ServiceC.init(serviceA)
+        }
+      
+      do {
+        let _ : ServiceRoot = try container.resolve()
+        XCTFail()
+      } catch {
+        switch error {
+        case let dipError as DipError:
+          XCTAssert(dipError.isRecusiveError)
+          
+          guard let report = dipError.analyzeRecursiveError() else {
+            XCTFail()
+            return
+          }
+          print(report)
+        default:
+          XCTFail()
+        }
+      }
+    }
+
+}

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -61,7 +61,7 @@ public final class DependencyContainer {
   
   public static var enableAutoInjection: Bool? = nil;
   
-  public static var maxRecusiveDepth: Int = 100
+  public static var maxRecursiveDepth: Int = 100
 
   /**
    Designated initializer for a DependencyContainer
@@ -221,7 +221,7 @@ extension DependencyContainer {
     return try threadSafe {
       let currentContext = self.context
       
-      if currentContext?.depth ?? 0 > DependencyContainer.maxRecusiveDepth {
+      if currentContext?.depth ?? 0 > DependencyContainer.maxRecursiveDepth {
         throw DipError.recursionDepthReached(key: aKey)
       }
       

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -60,6 +60,8 @@ public final class DependencyContainer {
   }
   
   public static var enableAutoInjection: Bool? = nil;
+  
+  public static var maxRecusiveDepth: Int = 100
 
   /**
    Designated initializer for a DependencyContainer
@@ -182,12 +184,15 @@ extension DependencyContainer {
     
     var logErrors: Bool = true
     
-    init(key: DefinitionKey, injectedInType: Any.Type?, injectedInProperty: String?, inCollaboration: Bool, container: DependencyContainer) {
+    let depth : Int
+    
+    init(key: DefinitionKey, injectedInType: Any.Type?, injectedInProperty: String?, inCollaboration: Bool, container: DependencyContainer, depth: Int) {
       self.key = key
       self.injectedInType = injectedInType
       self.injectedInProperty = injectedInProperty
       self.inCollaboration = inCollaboration
       self.container = container
+      self.depth = depth
     }
     
     public var debugDescription: String {
@@ -216,6 +221,10 @@ extension DependencyContainer {
     return try threadSafe {
       let currentContext = self.context
       
+      if currentContext?.depth ?? 0 > DependencyContainer.maxRecusiveDepth {
+        throw DipError.recursionDepthReached(key: aKey)
+      }
+      
       defer {
         context = currentContext
         
@@ -243,7 +252,8 @@ extension DependencyContainer {
         injectedInType: injectedInType,
         injectedInProperty: injectedInProperty,
         inCollaboration: inCollaboration,
-        container: container
+        container: container,
+        depth: (currentContext?.depth ?? -1) + 1
       )
       context.logErrors = logErrors ?? currentContext?.logErrors ?? true
       

--- a/Sources/DipError.swift
+++ b/Sources/DipError.swift
@@ -119,10 +119,10 @@ extension DipError {
   
   public struct RecuriveErrorReport: CustomStringConvertible {
     //The enture resolve stack that resulted in the recursive depth error
-    let resolveStack: [Any.Type]
+    public let resolveStack: [Any.Type]
     
     //The sub stack that was identified as a cycle, if any.
-    let cycleSubStack: [Any.Type]
+    public let cycleSubStack: [Any.Type]
     
     public var description: String {
       if(cycleSubStack.count > 0) {

--- a/Sources/DipError.swift
+++ b/Sources/DipError.swift
@@ -125,7 +125,7 @@ extension DipError {
     public let cycleSubStack: [Any.Type]
     
     public var description: String {
-      if(cycleSubStack.count > 0) {
+      if cycleSubStack.count > 0 {
         return "Recursive Depth exceeded: Cycle Found: \(cycleSubStack)"
       }
       return "Recursive Depth exceeded. No cycle found (inconclusive). Full stack: \(resolveStack)"
@@ -133,7 +133,7 @@ extension DipError {
   }
   
   public func analyzeRecursiveError() -> RecuriveErrorReport? {
-    if !isRecusiveError {
+    guard isRecusiveError else {
       return nil
     }
     
@@ -146,8 +146,6 @@ extension DipError {
           if let dipError = underlyingError as? DipError {
               buildStack(error: dipError)
           }
-          return
-        case .recursionDepthReached:
           return
         default:
           return
@@ -162,11 +160,10 @@ extension DipError {
     for (index, element) in resolveStack.enumerated() {
       let entryText = String(reflecting: element)
       let hit = (hitCount[entryText] ?? 0) + 1
-      if(hit == 2) {
-        let _last = resolveStack[0..<index].lastIndex { (type) -> Bool in
+      if hit == 2 {
+        guard let last = resolveStack[0..<index].lastIndex(where: { (type) -> Bool in
                    return String(reflecting: type) == entryText
-               }
-        guard let last = _last else {
+          }) else {
           break
         }
         
@@ -176,9 +173,8 @@ extension DipError {
       hitCount[entryText] = hit
     }
     
-    //Return result
     return RecuriveErrorReport.init(resolveStack: resolveStack,
-                                    cycleSubStack:cycleSubStack)
+                                    cycleSubStack: cycleSubStack)
   }
 }
 

--- a/Sources/DipError.swift
+++ b/Sources/DipError.swift
@@ -84,7 +84,7 @@ public enum DipError: Error, CustomStringConvertible {
   public var description: String {
     switch self {
     case let .recursionDepthReached(key: key):
-      return "recusion:\(key)"
+      return "Max recusion depth reached:\(key)"
     case let .definitionNotFound(key):
       return "No definition registered for \(key).\nCheck the tag, type you try to resolve, number, order and types of runtime arguments passed to `resolve()` and match them with registered factories for type \(key.type)."
     case let .autoInjectionFailed(label, type, error):
@@ -103,11 +103,11 @@ public enum DipError: Error, CustomStringConvertible {
 extension DipError {
   
   /// Informs you if the resolve failed because recursive limit was reached. Warning: O(n) for depth. May be slow
-  public var isRecusiveError: Bool {
+  public var isRecursiveError: Bool {
     switch self {
       case let .autoWiringFailed(type: _, underlyingError: underlyingError):
         if let dipError = underlyingError as? DipError {
-          return dipError.isRecusiveError
+          return dipError.isRecursiveError
         }
         return false
       case .recursionDepthReached:
@@ -117,7 +117,7 @@ extension DipError {
     }
   }
   
-  public struct RecuriveErrorReport: CustomStringConvertible {
+  public struct RecursiveErrorReport: CustomStringConvertible {
     //The enture resolve stack that resulted in the recursive depth error
     public let resolveStack: [Any.Type]
     
@@ -132,8 +132,8 @@ extension DipError {
     }
   }
   
-  public func analyzeRecursiveError() -> RecuriveErrorReport? {
-    guard isRecusiveError else {
+  public func analyzeRecursiveError() -> RecursiveErrorReport? {
+    guard isRecursiveError else {
       return nil
     }
     
@@ -173,7 +173,7 @@ extension DipError {
       hitCount[entryText] = hit
     }
     
-    return RecuriveErrorReport.init(resolveStack: resolveStack,
+    return RecursiveErrorReport.init(resolveStack: resolveStack,
                                     cycleSubStack: cycleSubStack)
   }
 }

--- a/Sources/DipError.swift
+++ b/Sources/DipError.swift
@@ -103,7 +103,7 @@ public enum DipError: Error, CustomStringConvertible {
 extension DipError {
   
   /// Informs you if the resolve failed because recursive limit was reached. Warning: O(n) for depth. May be slow
-  var isRecusiveError: Bool {
+  public var isRecusiveError: Bool {
     switch self {
       case let .autoWiringFailed(type: _, underlyingError: underlyingError):
         if let dipError = underlyingError as? DipError {
@@ -117,21 +117,22 @@ extension DipError {
     }
   }
   
-  struct RecuriveErrorReport: CustomStringConvertible {
+  public struct RecuriveErrorReport: CustomStringConvertible {
     //The enture resolve stack that resulted in the recursive depth error
     let resolveStack: [Any.Type]
     
     //The sub stack that was identified as a cycle, if any.
     let cycleSubStack: [Any.Type]
     
-    var description: String {
+    public var description: String {
       if(cycleSubStack.count > 0) {
         return "Recursive Depth exceeded: Cycle Found: \(cycleSubStack)"
       }
       return "Recursive Depth exceeded. No cycle found (inconclusive). Full stack: \(resolveStack)"
     }
   }
-  func analyzeRecursiveError() -> RecuriveErrorReport? {
+  
+  public func analyzeRecursiveError() -> RecuriveErrorReport? {
     if !isRecusiveError {
       return nil
     }


### PR DESCRIPTION
We had our call stack blowing up regularly. 
Add a new Dip Error and reporting to help identify recursive errors.

It can print out a report like the following:

```
Recursive Depth exceeded: Cycle Found: [DipTests.RecusiveTests.(unknown context at $106ad07f8).ServiceA, DipTests.RecusiveTests.(unknown context at $106ad0758).ServiceB, DipTests.RecusiveTests.(unknown context at $106ad06b8).ServiceC]
```

The Max is defaulted to 100. Can be configured statically.